### PR TITLE
Bugfix: only attempt to deploy to the RPCSX site hosting if running from a push to the main repo

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,6 +2,7 @@ name: Build Vue
 on: [push]
 jobs:
   build_vue:
+    if: github.repository_owner == 'RPCSX'
     runs-on: ubuntu-latest
     name: Build Vue
     steps:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,8 +1,8 @@
 # Contributing
 
-* Fork the repo
+* [Fork the repo](https://github.com/RPCSX/rpcsx-site/fork)
 * Create a branch following conventions: `username-feature`
   * ex. `git checkout -b OCDkirby-titlebar`
 * Commit changes and push the branch to your fork
-* Open a PR
-* Profit
+* Open a PR detailing your changes
+* Discuss edits with maintainers, if any


### PR DESCRIPTION
This can serve as a model pull request.

The workflow deploying the site to GitHub Pages at https://rpcsx.github.io/rpcsx-site/ would attempt to run from forks if the forks were pushed to. This would always error out because a fork does not have write access to the upstream repo's pages hosting.

Also updated [CONTRIBUTING.md](CONTRIBUTING.md) to reflect the changes.